### PR TITLE
Share bugfixes

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -21,6 +21,12 @@ body {
 }
 
 /* === Links Section === */
+.links-section:hover {
+	.share-btn, .whatsapp-btn, .telegram-btn {
+		display: inline-block;
+	}
+}
+
 .links-section h2 {
 	align-items: center;
 	display: flex;

--- a/assets/js/share.js
+++ b/assets/js/share.js
@@ -9,6 +9,12 @@ function handleDetailsToggle(event) {
   const sections = document.querySelectorAll('details');
   const clickedSection = event.target.closest('details');
 
+  if (!clickedSection.hasAttribute('open')) {
+    history.pushState({}, '', `#${clickedSection.id}`);
+  } else {
+    history.pushState({}, '', '#');
+  }
+
   sections.forEach((section) => {
     if (section !== clickedSection) { // Don't close the one being toggled by the user.
       section.removeAttribute('open');
@@ -59,6 +65,7 @@ function addShareButtonListeners() {
   shareBtns.forEach((btn) => {
     btn.addEventListener("click", (e) => {
       e.preventDefault();
+      e.stopPropagation();
       const sectionUrl = `${siteUrl.origin}#${btn.getAttribute("data-index")}`;
 
       navigator.clipboard.writeText(sectionUrl);
@@ -78,7 +85,8 @@ function addExternalShareListeners(externalService) {
   btns.forEach((btn) => {
     btn.addEventListener("click", (e) => {
       e.preventDefault();
-      const sectionUrl = `${siteUrl.origin}#${btn.getAttribute("data-index")}`;
+      e.stopPropagation();
+      const sectionUrl = encodeURIComponent(`${siteUrl.origin}#${btn.getAttribute("data-index")}`);
       const shareUrls = {
         whatsapp: `https://api.whatsapp.com/send?text=${sectionUrl}`,
         telegram: `https://t.me/share/url?url=${sectionUrl}`,
@@ -96,16 +104,23 @@ function scrollToSectionInView() {
     const section = document.querySelector(sectionId);
     if (section) {
       section.scrollIntoView({ behavior: "smooth" });
+      section.setAttribute("open", "");
     }
   }
 }
 
-(() => {
-  initializeShareButtons();
-  openSectionFromHash();
-  addShareButtonListeners();
-  addExternalShareListeners("whatsapp");
-  addExternalShareListeners("telegram");
-  scrollToSectionInView();
-  bindDetailsToggleEvent(); // Call the new function.
-})();
+window.addEventListener(
+  "DOMContentLoaded",
+  () => {
+    initializeShareButtons();
+    openSectionFromHash();
+    addShareButtonListeners();
+    addExternalShareListeners("whatsapp");
+    addExternalShareListeners("telegram");
+    scrollToSectionInView();
+    bindDetailsToggleEvent(); // Call the new function.
+
+    window.addEventListener("hashchange", scrollToSectionInView);
+  },
+  false
+);

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ direction: rtl
 ---
 
 {% for category in site.data.links %}
-<details class="links-section" id="initiatives">
+<details class="links-section" id="{{ category.name }}">
 <summary class="links-section-title">
 <h2>{{ category.displayName }}</h2>
 <div class="open-caret"></div>


### PR DESCRIPTION
A few share buttons-related bugfixes and features:

Bugfixes:
- Sections now have different IDs.
- Clicking on the "copy link" button doesn't close the section anymore.
- Anchor links behavior of scrolling to the correct section and opening it now works.
- Button appending code now runs after the DOM is ready, solving a bug where the buttons didn't always appear.
- WhatsApp And Telegram share buttons now encoded properly, so the right link is shared.
- Navigating with back/forwards in the site (between links to different sections) now works as expected.

Features:
- Share buttons now appear on hover as well as when the section is open.
- Clicking on a section changes the site's URL to that section's.