### PR TITLE
trim search term

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -161,7 +161,7 @@ document.addEventListener("DOMContentLoaded", function () {
   });
 
   searchInputWeb.addEventListener("input", function (event) {
-    const searchTerm = event.target.value;
+    const searchTerm = event.target.value.trim();
 
     if (searchTerm) {
       overlayElementWeb.classList.add("active");


### PR DESCRIPTION
Don't issue a search if the search box contains only white spaces.

Today, if you type a space in the search bar, you get a list with all links, which doesn't really make sense.