### PR TITLE
Fix link in search results

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -63,7 +63,7 @@ function displaySearchResults(results, links) {
       const siteUrl = new URL(window.location.href);
       const permalink = `${siteUrl.origin}#${item.name}`;
 
-      appendString += `<div class="searchResultLinks"><a href="${item.url}" onclick="return clearInput();">קח אותי ליוזמה</a> / <a onclick="searchResultClicked(${item.name})">עוד מידע</a></div></div></li>`;
+      appendString += `<div class="searchResultLinks"><a href="${item.url}" target="_blank">קח אותי ליוזמה</a> / <a onclick="searchResultClicked(${item.name})">עוד מידע</a></div></div></li>`;
     }
 
     searchResults.innerHTML = appendString;


### PR DESCRIPTION
Today, site link in search results only clear the search box, but doesn't open the site. This is because of the `onclick` attribute.

Since we open site links in a new tab, there is no need to clear the search box when a site link is clicked.